### PR TITLE
Default inventory

### DIFF
--- a/app/assets/javascripts/admin/services/variant_overrides.js.coffee
+++ b/app/assets/javascripts/admin/services/variant_overrides.js.coffee
@@ -18,7 +18,7 @@ angular.module("ofn.admin").factory "VariantOverrides", (variantOverrides, Index
               price: ''
               count_on_hand: ''
               default_stock: ''
-              enable_reset: false
+              resettable: false
 
     updateIds: (updatedVos) ->
       for vo in updatedVos

--- a/app/controllers/admin/enterprise_fees_controller.rb
+++ b/app/controllers/admin/enterprise_fees_controller.rb
@@ -89,7 +89,7 @@ module Admin
     end
 
     def collection_actions
-      [:index, :for_order_cycle]
+      [:index, :for_order_cycle, :bulk_update]
     end
 
     def current_enterprise

--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -141,5 +141,9 @@ module Admin
         end
       end
     end
+
+    def collection_actions
+      [:index, :bulk_update]
+    end
   end
 end

--- a/app/controllers/admin/variant_overrides_controller.rb
+++ b/app/controllers/admin/variant_overrides_controller.rb
@@ -6,23 +6,22 @@ module Admin
 
     before_filter :load_spree_api_key, only: :index
     before_filter :load_data
+    before_filter :load_collection, only: [:bulk_update, :bulk_reset]
 
     def index
     end
 
 
     def bulk_update
-      collection_hash = Hash[params[:variant_overrides].each_with_index.map { |vo, i| [i, vo] }]
-      vo_set = VariantOverrideSet.new @variant_overrides, collection_attributes: collection_hash
       # Ensure we're authorised to update all variant overrides
-      vo_set.collection.each { |vo| authorize! :update, vo }
+      @vo_set.collection.each { |vo| authorize! :update, vo }
 
-      if vo_set.save
+      if @vo_set.save
         # Return saved VOs with IDs
-        render json: vo_set.collection, each_serializer: Api::Admin::VariantOverrideSerializer
+        render json: @vo_set.collection, each_serializer: Api::Admin::VariantOverrideSerializer
       else
-        if vo_set.errors.present?
-          render json: { errors: vo_set.errors }, status: 400
+        if @vo_set.errors.present?
+          render json: { errors: @vo_set.errors }, status: 400
         else
           render nothing: true, status: 500
         end
@@ -30,18 +29,15 @@ module Admin
     end
 
     def bulk_reset
-      collection_hash = Hash[params[:variant_overrides].each_with_index.map { |vo, i| [i, vo] }]
-      vo_set = VariantOverrideSet.new @variant_overrides, collection_attributes: collection_hash
-
       # Ensure we're authorised to update all variant overrides.
-      vo_set.collection.each { |vo| authorize! :bulk_reset, vo }
+      @vo_set.collection.each { |vo| authorize! :bulk_reset, vo }
 
       # Changed this to use class method instead, to ensure the value in the database is used to reset and not a dirty passed-in value
       #vo_set.collection.map! { |vo| vo = vo.reset_stock! }
-      vo_set.collection.map! { |vo| VariantOverride.reset_stock!(vo.hub,vo.variant) }
-      render json: vo_set.collection, each_serializer: Api::Admin::VariantOverrideSerializer
-      if vo_set.errors.present?
-        render json: { errors: vo_set.errors }, status: 400
+      @vo_set.collection.map! { |vo| VariantOverride.reset_stock!(vo.hub,vo.variant) }
+      render json: @vo_set.collection, each_serializer: Api::Admin::VariantOverrideSerializer
+      if @vo_set.errors.present?
+        render json: { errors: @vo_set.errors }, status: 400
       end
     end
 
@@ -59,6 +55,11 @@ module Admin
       @hub_permissions = OpenFoodNetwork::Permissions.new(spree_current_user).
         variant_override_enterprises_per_hub
       @variant_overrides = VariantOverride.for_hubs(@hubs)
+    end
+
+    def load_collection
+      collection_hash = Hash[params[:variant_overrides].each_with_index.map { |vo, i| [i, vo] }]
+      @vo_set = VariantOverrideSet.new @variant_overrides, collection_attributes: collection_hash
     end
 
     def collection

--- a/app/controllers/admin/variant_overrides_controller.rb
+++ b/app/controllers/admin/variant_overrides_controller.rb
@@ -34,7 +34,7 @@ module Admin
       vo_set = VariantOverrideSet.new @variant_overrides, collection_attributes: collection_hash
 
       # Ensure we're authorised to update all variant overrides.
-      vo_set.collection.each { |vo| authorize! :update, vo }
+      vo_set.collection.each { |vo| authorize! :bulk_reset, vo }
 
       # Changed this to use class method instead, to ensure the value in the database is used to reset and not a dirty passed-in value
       #vo_set.collection.map! { |vo| vo = vo.reset_stock! }
@@ -65,7 +65,7 @@ module Admin
     end
 
     def collection_actions
-      [:index, :bulk_update]
+      [:index, :bulk_update, :bulk_reset]
     end
   end
 end

--- a/app/controllers/admin/variant_overrides_controller.rb
+++ b/app/controllers/admin/variant_overrides_controller.rb
@@ -63,5 +63,9 @@ module Admin
 
     def collection
     end
+
+    def collection_actions
+      [:index, :bulk_update]
+    end
   end
 end

--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -66,7 +66,7 @@ class AbilityDecorator
   def add_enterprise_management_abilities(user)
     # Spree performs authorize! on (:create, nil) when creating a new order from admin, and also (:search, nil)
     # when searching for variants to add to the order
-    can [:create, :search, :bulk_update], nil
+    can [:create, :search], nil
 
     can [:admin, :index], :overview
 

--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -104,7 +104,7 @@ class AbilityDecorator
       OpenFoodNetwork::Permissions.new(user).managed_product_enterprises.include? variant.product.supplier
     end
 
-    can [:admin, :index, :read, :update, :bulk_update], VariantOverride do |vo|
+    can [:admin, :index, :read, :update, :bulk_update, :bulk_reset], VariantOverride do |vo|
       hub_auth = OpenFoodNetwork::Permissions.new(user).
         variant_override_hubs.
         include? vo.hub

--- a/app/models/variant_override.rb
+++ b/app/models/variant_override.rb
@@ -56,7 +56,7 @@ class VariantOverride < ActiveRecord::Base
   end
 
   def reset_stock!
-    if enable_reset
+    if resettable
       if default_stock?
         self.attributes = { count_on_hand: default_stock }
         self.save

--- a/app/models/variant_override_set.rb
+++ b/app/models/variant_override_set.rb
@@ -3,6 +3,6 @@ class VariantOverrideSet < ModelSet
     super(VariantOverride, collection, attributes, nil,
           # I have no idea what this does but had to add all fields to get it to create a new VO when only a new field was changed.
           # i.e. a field unique to Variant Override (default_stock and reset) and not present in Variant.
-          proc { |attrs| attrs['price'].blank? && attrs['count_on_hand'].blank? && attrs['default_stock'].blank? && attrs['enable_reset'].blank?} )
+          proc { |attrs| attrs['price'].blank? && attrs['count_on_hand'].blank? && attrs['default_stock'].blank? && attrs['resettable'].blank?} )
   end
 end

--- a/app/serializers/api/admin/variant_override_serializer.rb
+++ b/app/serializers/api/admin/variant_override_serializer.rb
@@ -1,3 +1,3 @@
 class Api::Admin::VariantOverrideSerializer < ActiveModel::Serializer
-  attributes :id, :hub_id, :variant_id, :price, :count_on_hand, :default_stock, :enable_reset
+  attributes :id, :hub_id, :variant_id, :price, :count_on_hand, :default_stock, :resettable
 end

--- a/app/views/admin/variant_overrides/_products_variants.html.haml
+++ b/app/views/admin/variant_overrides/_products_variants.html.haml
@@ -10,6 +10,6 @@
     %input{name: 'variant-overrides-{{ variant.id }}-count-on-hand', type: 'text', ng: {model: 'variantOverrides[hub.id][variant.id].count_on_hand'}, placeholder: '{{ variant.on_hand }}', 'ofn-track-variant-override' => 'count_on_hand'}
 
   %td
-    %input{name: 'variant-overrides-{{ variant.id }}-enable_reset', type: 'checkbox', ng: {model: 'variantOverrides[hub.id][variant.id].enable_reset'}, placeholder: '{{ variant.enable_reset }}', 'ofn-track-variant-override' => 'enable_reset'}
+    %input{name: 'variant-overrides-{{ variant.id }}-enable-reset', type: 'checkbox', ng: {model: 'variantOverrides[hub.id][variant.id].enable_reset'}, placeholder: '{{ variant.enable_reset }}', 'ofn-track-variant-override' => 'enable_reset'}
   %td
     %input{name: 'variant-overrides-{{ variant.id }}-default-stock', type: 'text', ng: {model: 'variantOverrides[hub.id][variant.id].default_stock'}, placeholder: '{{ variant.default_stock ? variant.default_stock : "Default stock"}}', 'ofn-track-variant-override' => 'default_stock'}

--- a/app/views/admin/variant_overrides/_products_variants.html.haml
+++ b/app/views/admin/variant_overrides/_products_variants.html.haml
@@ -10,6 +10,6 @@
     %input{name: 'variant-overrides-{{ variant.id }}-count-on-hand', type: 'text', ng: {model: 'variantOverrides[hub.id][variant.id].count_on_hand'}, placeholder: '{{ variant.on_hand }}', 'ofn-track-variant-override' => 'count_on_hand'}
 
   %td
-    %input{name: 'variant-overrides-{{ variant.id }}-enable-reset', type: 'checkbox', ng: {model: 'variantOverrides[hub.id][variant.id].enable_reset'}, placeholder: '{{ variant.enable_reset }}', 'ofn-track-variant-override' => 'enable_reset'}
+    %input{name: 'variant-overrides-{{ variant.id }}-resettable', type: 'checkbox', ng: {model: 'variantOverrides[hub.id][variant.id].resettable'}, placeholder: '{{ variant.resettable }}', 'ofn-track-variant-override' => 'resettable'}
   %td
     %input{name: 'variant-overrides-{{ variant.id }}-default-stock', type: 'text', ng: {model: 'variantOverrides[hub.id][variant.id].default_stock'}, placeholder: '{{ variant.default_stock ? variant.default_stock : "Default stock"}}', 'ofn-track-variant-override' => 'default_stock'}

--- a/db/migrate/20151128185900_rename_enable_reset_to_resettable.rb
+++ b/db/migrate/20151128185900_rename_enable_reset_to_resettable.rb
@@ -1,0 +1,3 @@
+class RenameEnableResetToResettable < ActiveRecord::Migration
+	rename_column :variant_overrides, :enable_reset, :resettable
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150827194622) do
+ActiveRecord::Schema.define(:version => 20151128185900) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"
@@ -1123,7 +1123,7 @@ ActiveRecord::Schema.define(:version => 20150827194622) do
     t.decimal "price",         :precision => 8, :scale => 2
     t.integer "count_on_hand"
     t.integer "default_stock"
-    t.boolean "enable_reset"
+    t.boolean "resettable"
   end
 
   add_index "variant_overrides", ["variant_id", "hub_id"], :name => "index_variant_overrides_on_variant_id_and_hub_id"

--- a/spec/controllers/admin/variant_overrides_spec.rb
+++ b/spec/controllers/admin/variant_overrides_spec.rb
@@ -6,8 +6,8 @@ module Admin
     let!(:hub_owner) { create :user, enterprise_limit: 2 }
     let!(:v1) { create(:variant) }
     let!(:v2) { create(:variant) }
-    let!(:vo1) { create(:variant_override, hub: hub, variant: v1, price: "6.0", count_on_hand: 5, default_stock: 7, enable_reset: true) }
-    let!(:vo2) { create(:variant_override, hub: hub, variant: v2, price: "6.0", count_on_hand: 2, default_stock: 1, enable_reset: false) }
+    let!(:vo1) { create(:variant_override, hub: hub, variant: v1, price: "6.0", count_on_hand: 5, default_stock: 7, resettable: true) }
+    let!(:vo2) { create(:variant_override, hub: hub, variant: v2, price: "6.0", count_on_hand: 2, default_stock: 1, resettable: false) }
 
     before do
       controller.stub spree_current_user: hub_owner

--- a/spec/controllers/admin/variant_overrides_spec.rb
+++ b/spec/controllers/admin/variant_overrides_spec.rb
@@ -3,57 +3,72 @@ require 'spec_helper'
 module Admin
   describe VariantOverridesController, type: :controller do
     include AuthenticationWorkflow
-    let!(:hub_owner) { create :admin_user, enterprise_limit: 2 }
+    let!(:hub_owner) { create :user, enterprise_limit: 2 }
+    let!(:v1) { create(:variant) }
+    let!(:v2) { create(:variant) }
+    let!(:vo1) { create(:variant_override, hub: hub, variant: v1, price: "6.0", count_on_hand: 5, default_stock: 7, enable_reset: true) }
+    let!(:vo2) { create(:variant_override, hub: hub, variant: v2, price: "6.0", count_on_hand: 2, default_stock: 1, enable_reset: false) }
 
     before do
       controller.stub spree_current_user: hub_owner
     end
 
     describe "bulk_update" do
-      context "as an enterprise user I update the variant overrides" do
-        let!(:hub) { create(:distributor_enterprise, owner: hub_owner) }
+      let!(:hub) { create(:distributor_enterprise, owner: hub_owner) }
+      let(:params) { { variant_overrides: [{id: vo1.id, price: "10.0"}, {id: vo2.id, default_stock: 12 }] } }
+
+      context "where the producer has not granted create_variant_overrides permission to the hub" do
+        it "restricts access" do
+          spree_put :bulk_update, params
+          expect(response).to redirect_to spree.unauthorized_path
+        end
+      end
+
+      context "where the producer has granted create_variant_overrides permission to the hub" do
+        let!(:er1) { create(:enterprise_relationship, parent: v1.product.supplier, child: hub, permissions_list: [:create_variant_overrides]) }
+
         it "updates the overrides correctly" do
-          v1 = create(:variant)
-          v2 = create(:variant)
-          vo1 = create(:variant_override, hub: hub, variant: v1, price: "6.0", count_on_hand: 5, default_stock: 7)
-          vo2 = create(:variant_override, hub: hub, variant: v2, price: "6.0", count_on_hand: 5, default_stock: 7)
-          vo1.price = "10.0"
-          vo2.default_stock = 12
-          # Have to use .attributes as otherwise passes just the ID
-          spree_put :bulk_update, {variant_overrides: [vo1.attributes, vo2.attributes]}
-	        # Retrieve from database
-          VariantOverride.find(vo1.id).price.should eq 10
-	        VariantOverride.find(vo2.id).default_stock.should eq 12
+          spree_put :bulk_update, params
+          vo1.reload.price.should eq 10
+	        vo2.reload.default_stock.should eq 12
         end
       end
     end
+
     describe "bulk_reset" do
       let!(:hub) { create(:distributor_enterprise, owner: hub_owner) }
+
       before do
         controller.stub spree_current_user: hub.owner
       end
-      context "when a reset request is received" do
-        it "updates stock to default values" do
-        v1 = create(:variant)
-        v2 = create(:variant)
-        vo1 = create(:variant_override, hub: hub, variant: v1, price: "6.0", count_on_hand: 5, default_stock: 7, enable_reset: true)
-        vo2 = create(:variant_override, hub: hub, variant: v2, price: "6.0", count_on_hand: 2, default_stock: 1, enable_reset: false)
-        params = {"variant_overrides" => [vo1.attributes, vo2.attributes]}
-        spree_put :bulk_reset, params
 
-        vo1.reload
-        expect(vo1.count_on_hand).to eq 7
-        end
-        it "doesn't update where reset is disabled" do
-          v1 = create(:variant)
-          v2 = create(:variant)
-          vo1 = create(:variant_override, hub: hub, variant: v1, price: "6.0", count_on_hand: 5, default_stock: 7, enable_reset: true)
-          vo2 = create(:variant_override, hub: hub, variant: v2, price: "6.0", count_on_hand: 2, default_stock: 1, enable_reset: false)
-          params = {"variant_overrides" => [vo1.attributes, vo2.attributes]}
+      context "where the producer has not granted create_variant_overrides permission to the hub" do
+        let(:params) { { variant_overrides: [ { id: vo1 } ] } }
+
+        it "restricts access" do
           spree_put :bulk_reset, params
-          
-          vo2.reload
-          expect(vo2.count_on_hand).to eq 2
+          expect(response).to redirect_to spree.unauthorized_path
+        end
+      end
+
+      context "where the producer has granted create_variant_overrides permission to the hub" do
+        let!(:er1) { create(:enterprise_relationship, parent: v1.product.supplier, child: hub, permissions_list: [:create_variant_overrides]) }
+
+        context "where reset is enabled" do
+          let(:params) { { variant_overrides: [ { id: vo1 } ] } }
+
+          it "updates stock to default values" do
+            spree_put :bulk_reset, params
+            expect(vo1.reload.count_on_hand).to eq 7
+          end
+        end
+
+        context "where reset is disabled" do
+          let(:params) { { variant_overrides: [ { id: vo2 } ] } }
+          it "doesn't update on_hand" do
+            spree_put :bulk_reset, params
+            expect(vo2.reload.count_on_hand).to eq 2
+          end
         end
       end
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -93,7 +93,7 @@ FactoryGirl.define do
     price         77.77
     count_on_hand 11111
     default_stock 2000
-    enable_reset  false
+    resettable  false
   end
 
   factory :enterprise, :class => Enterprise do

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -180,7 +180,7 @@ feature %q{
             page.should have_content "Changes saved."
           end.to change(VariantOverride, :count).by(0)
 
-          vo.reload
+          vo = VariantOverride.last
           vo.variant_id.should == variant.id
           vo.hub_id.should == hub.id
           vo.price.should == 22.22
@@ -201,10 +201,10 @@ feature %q{
           VariantOverride.where(id: vo.id).should be_empty
         end
 
-        # Failing due to authentication issue
         it "resets stock to defaults" do
           click_button 'Reset Stock to Defaults'
-          vo.reload
+          page.should have_content 'Stocks reset to defaults.'
+          vo = VariantOverride.last
           vo.count_on_hand.should == 1000
           page.should have_input "variant-overrides-#{variant.id}-count-on-hand", with: '1000', placeholder: '12'
         end

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -157,7 +157,6 @@ feature %q{
       context "with overrides" do
         let!(:vo) { create(:variant_override, variant: variant, hub: hub, price: 77.77, count_on_hand: 11111, default_stock: 1000, enable_reset: true) }
         let!(:vo_no_auth) { create(:variant_override, variant: variant, hub: hub3, price: 1, count_on_hand: 2) }
-        let!(:vo_no_) { create(:variant_override, variant: variant, hub: hub, price: 77.77, count_on_hand: 11111, default_stock: 1000, enable_reset: false) }
 
         before do
           visit '/admin/variant_overrides'
@@ -180,7 +179,7 @@ feature %q{
             page.should have_content "Changes saved."
           end.to change(VariantOverride, :count).by(0)
 
-          vo = VariantOverride.last
+          vo.reload
           vo.variant_id.should == variant.id
           vo.hub_id.should == hub.id
           vo.price.should == 22.22
@@ -191,6 +190,8 @@ feature %q{
         it "deletes overrides when values are cleared" do
           fill_in "variant-overrides-#{variant.id}-price", with: ''
           fill_in "variant-overrides-#{variant.id}-count-on-hand", with: ''
+          fill_in "variant-overrides-#{variant.id}-default-stock", with: ''
+          page.uncheck "variant-overrides-#{variant.id}-enable-reset"
           page.should have_content "Changes to one override remain unsaved."
 
           expect do
@@ -204,9 +205,9 @@ feature %q{
         it "resets stock to defaults" do
           click_button 'Reset Stock to Defaults'
           page.should have_content 'Stocks reset to defaults.'
-          vo = VariantOverride.last
-          vo.count_on_hand.should == 1000
+          vo.reload
           page.should have_input "variant-overrides-#{variant.id}-count-on-hand", with: '1000', placeholder: '12'
+          vo.count_on_hand.should == 1000
         end
 
         it "prompts to save changes before reset if any are pending" do

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -155,9 +155,11 @@ feature %q{
       end
 
       context "with overrides" do
-        let!(:vo) { create(:variant_override, variant: variant, hub: hub, price: 77.77, count_on_hand: 11111, default_stock: 1000, enable_reset: true) }
+        let!(:vo) { create(:variant_override, variant: variant, hub: hub, price: 77.77, count_on_hand: 11111, default_stock: 1000, resettable: true) }
         let!(:vo_no_auth) { create(:variant_override, variant: variant, hub: hub3, price: 1, count_on_hand: 2) }
-
+        let!(:product2) { create(:simple_product, supplier: producer, variant_unit: 'weight', variant_unit_scale: 1) }
+        let!(:variant2) { create(:variant, product: product2, unit_value: 8, price: 1.00, on_hand: 12) }
+        let!(:vo_no_reset) { create(:variant_override, variant: variant2, hub: hub, price: 3.99, count_on_hand: 40, default_stock: 100, resettable: false) }
         before do
           visit '/admin/variant_overrides'
           select2_select hub.name, from: 'hub_id'
@@ -186,12 +188,12 @@ feature %q{
           vo.count_on_hand.should == 8888
         end
 
-        # This fails for me and can't find where this automatic deletion is implemented?
+        # Any new fields added to the VO model need to be added to this test
         it "deletes overrides when values are cleared" do
           fill_in "variant-overrides-#{variant.id}-price", with: ''
           fill_in "variant-overrides-#{variant.id}-count-on-hand", with: ''
           fill_in "variant-overrides-#{variant.id}-default-stock", with: ''
-          page.uncheck "variant-overrides-#{variant.id}-enable-reset"
+          page.uncheck "variant-overrides-#{variant.id}-resettable"
           page.should have_content "Changes to one override remain unsaved."
 
           expect do
@@ -209,6 +211,14 @@ feature %q{
           page.should have_input "variant-overrides-#{variant.id}-count-on-hand", with: '1000', placeholder: '12'
           vo.count_on_hand.should == 1000
         end
+
+        it "doesn't reset stock levels if the behaviour is disabled" do
+          click_button 'Reset Stock to Defaults'
+          vo_no_reset.reload
+          page.should have_input "variant-overrides-#{variant2.id}-count-on-hand", with: '40', placeholder: '12'
+          vo_no_reset.count_on_hand.should == 40
+        end
+
 
         it "prompts to save changes before reset if any are pending" do
           fill_in "variant-overrides-#{variant.id}-price", with: '200'

--- a/spec/javascripts/unit/admin/services/variant_overrides_spec.js.coffee
+++ b/spec/javascripts/unit/admin/services/variant_overrides_spec.js.coffee
@@ -1,9 +1,9 @@
 describe "VariantOverrides service", ->
   VariantOverrides = $httpBackend = null
   variantOverrides = [
-    {id: 1, hub_id: 10, variant_id: 100, price: 1, count_on_hand: 1, default_stock: ''}
-    {id: 2, hub_id: 10, variant_id: 200, price: 2, count_on_hand: 2, default_stock: ''}
-    {id: 3, hub_id: 20, variant_id: 300, price: 3, count_on_hand: 3, default_stock: ''}
+    {id: 1, hub_id: 10, variant_id: 100, price: 1, count_on_hand: 1, default_stock: '', resettable: false}
+    {id: 2, hub_id: 10, variant_id: 200, price: 2, count_on_hand: 2, default_stock: '', resettable: false}
+    {id: 3, hub_id: 20, variant_id: 300, price: 3, count_on_hand: 3, default_stock: '', resettable: false}
   ]
 
   beforeEach ->
@@ -19,10 +19,10 @@ describe "VariantOverrides service", ->
   it "indexes variant overrides by hub_id -> variant_id", ->
     expect(VariantOverrides.variantOverrides).toEqual
       10:
-        100: {id: 1, hub_id: 10, variant_id: 100, price: 1, count_on_hand: 1, default_stock: ''}
-        200: {id: 2, hub_id: 10, variant_id: 200, price: 2, count_on_hand: 2, default_stock: ''}
+        100: {id: 1, hub_id: 10, variant_id: 100, price: 1, count_on_hand: 1, default_stock: '', resettable: false}
+        200: {id: 2, hub_id: 10, variant_id: 200, price: 2, count_on_hand: 2, default_stock: '', resettable: false}
       20:
-        300: {id: 3, hub_id: 20, variant_id: 300, price: 3, count_on_hand: 3, default_stock: ''}
+        300: {id: 3, hub_id: 20, variant_id: 300, price: 3, count_on_hand: 3, default_stock: '', resettable: false}
 
   it "ensures blank data available for some products", ->
     hubs = [{id: 10}, {id: 20}, {id: 30}]
@@ -35,32 +35,32 @@ describe "VariantOverrides service", ->
     VariantOverrides.ensureDataFor hubs, products
     expect(VariantOverrides.variantOverrides).toEqual
       10:
-        100: {id: 1, hub_id: 10, variant_id: 100, price: 1, count_on_hand: 1, default_stock: ''}
-        200: {id: 2, hub_id: 10, variant_id: 200, price: 2, count_on_hand: 2, default_stock: ''}
-        300: {       hub_id: 10, variant_id: 300, price: '', count_on_hand: '', default_stock: ''}
-        400: {       hub_id: 10, variant_id: 400, price: '', count_on_hand: '', default_stock: ''}
-        500: {       hub_id: 10, variant_id: 500, price: '', count_on_hand: '', default_stock: ''}
+        100: {id: 1, hub_id: 10, variant_id: 100, price: 1, count_on_hand: 1, default_stock: '', resettable: false}
+        200: {id: 2, hub_id: 10, variant_id: 200, price: 2, count_on_hand: 2, default_stock: '', resettable: false}
+        300: {       hub_id: 10, variant_id: 300, price: '', count_on_hand: '', default_stock: '', resettable: false}
+        400: {       hub_id: 10, variant_id: 400, price: '', count_on_hand: '', default_stock: '', resettable: false}
+        500: {       hub_id: 10, variant_id: 500, price: '', count_on_hand: '', default_stock: '', resettable: false}
       20:
-        100: {       hub_id: 20, variant_id: 100, price: '', count_on_hand: '', default_stock: ''}
-        200: {       hub_id: 20, variant_id: 200, price: '', count_on_hand: '', default_stock: ''}
-        300: {id: 3, hub_id: 20, variant_id: 300, price: 3, count_on_hand: 3, default_stock: ''}
-        400: {       hub_id: 20, variant_id: 400, price: '', count_on_hand: '', default_stock: ''}
-        500: {       hub_id: 20, variant_id: 500, price: '', count_on_hand: '', default_stock: ''}
+        100: {       hub_id: 20, variant_id: 100, price: '', count_on_hand: '', default_stock: '', resettable: false}
+        200: {       hub_id: 20, variant_id: 200, price: '', count_on_hand: '', default_stock: '', resettable: false}
+        300: {id: 3, hub_id: 20, variant_id: 300, price: 3, count_on_hand: 3, default_stock: '', resettable: false}
+        400: {       hub_id: 20, variant_id: 400, price: '', count_on_hand: '', default_stock: '', resettable: false}
+        500: {       hub_id: 20, variant_id: 500, price: '', count_on_hand: '', default_stock: '', resettable: false}
       30:
-        100: {       hub_id: 30, variant_id: 100, price: '', count_on_hand: '', default_stock: ''}
-        200: {       hub_id: 30, variant_id: 200, price: '', count_on_hand: '', default_stock: ''}
-        300: {       hub_id: 30, variant_id: 300, price: '', count_on_hand: '', default_stock: ''}
-        400: {       hub_id: 30, variant_id: 400, price: '', count_on_hand: '', default_stock: ''}
-        500: {       hub_id: 30, variant_id: 500, price: '', count_on_hand: '', default_stock: ''}
+        100: {       hub_id: 30, variant_id: 100, price: '', count_on_hand: '', default_stock: '', resettable: false}
+        200: {       hub_id: 30, variant_id: 200, price: '', count_on_hand: '', default_stock: '', resettable: false}
+        300: {       hub_id: 30, variant_id: 300, price: '', count_on_hand: '', default_stock: '', resettable: false}
+        400: {       hub_id: 30, variant_id: 400, price: '', count_on_hand: '', default_stock: '', resettable: false}
+        500: {       hub_id: 30, variant_id: 500, price: '', count_on_hand: '', default_stock: '', resettable: false}
 
   it "updates the IDs of variant overrides", ->
     VariantOverrides.variantOverrides[2] = {}
-    VariantOverrides.variantOverrides[2][3] = {hub_id: 2, variant_id: 3, price: "4.0", count_on_hand: 5, default_stock: ''}
-    VariantOverrides.variantOverrides[2][8] = {hub_id: 2, variant_id: 8, price: "9.0", count_on_hand: 10, default_stock: ''}
+    VariantOverrides.variantOverrides[2][3] = {hub_id: 2, variant_id: 3, price: "4.0", count_on_hand: 5, default_stock: '', resettable: false}
+    VariantOverrides.variantOverrides[2][8] = {hub_id: 2, variant_id: 8, price: "9.0", count_on_hand: 10, default_stock: '', resettable: false}
 
     updatedVos = [
-      {id: 1, hub_id: 2, variant_id: 3, price: "4.0", count_on_hand: 5, default_stock: ''}
-      {id: 6, hub_id: 2, variant_id: 8, price: "9.0", count_on_hand: 10, default_stock: ''}
+      {id: 1, hub_id: 2, variant_id: 3, price: "4.0", count_on_hand: 5, default_stock: '', resettable: false}
+      {id: 6, hub_id: 2, variant_id: 8, price: "9.0", count_on_hand: 10, default_stock: '', resettable: false}
     ]
 
     VariantOverrides.updateIds updatedVos
@@ -75,14 +75,14 @@ describe "VariantOverrides service", ->
 
   it "updates the variant overrides on the page with new data", ->
     VariantOverrides.variantOverrides[1] =
-      3: {id: 1, hub_id: 1, variant_id: 3, price: "4.0", count_on_hand: 5, default_stock: 3}
-      8: {id: 2, hub_id: 1, variant_id: 8, price: "9.0", count_on_hand: 10, default_stock: ''}
+      3: {id: 1, hub_id: 1, variant_id: 3, price: "4.0", count_on_hand: 5, default_stock: 3, resettable: true}
+      8: {id: 2, hub_id: 1, variant_id: 8, price: "9.0", count_on_hand: 10, default_stock: '', resettable: false}
       # Updated count on hand to 3
     updatedVos = [
-      {id: 1, hub_id: 1, variant_id: 3, price: "4.0", count_on_hand: 3, default_stock: 3}
+      {id: 1, hub_id: 1, variant_id: 3, price: "4.0", count_on_hand: 3, default_stock: 3, resettable: true}
     ]
 
     VariantOverrides.updateData(updatedVos)
     expect(VariantOverrides.variantOverrides[1]).toEqual
-      3: {id: 1, hub_id: 1, variant_id: 3, price: "4.0", count_on_hand: 3, default_stock: 3}
-      8: {id: 2, hub_id: 1, variant_id: 8, price: "9.0", count_on_hand: 10, default_stock: ''}
+      3: {id: 1, hub_id: 1, variant_id: 3, price: "4.0", count_on_hand: 3, default_stock: 3, resettable: true}
+      8: {id: 2, hub_id: 1, variant_id: 8, price: "9.0", count_on_hand: 10, default_stock: '', resettable: false}

--- a/spec/models/spree/ability_spec.rb
+++ b/spec/models/spree/ability_spec.rb
@@ -323,7 +323,7 @@ module Spree
           let!(:er1) { create(:enterprise_relationship, parent: s1, child: d1, permissions_list: [:create_variant_overrides]) }
 
           it "should be able to access variant overrides page" do
-            should have_ability([:admin, :index, :bulk_update], for: VariantOverride)
+            should have_ability([:admin, :index, :bulk_update, :bulk_reset], for: VariantOverride)
           end
 
           it "should be able to read/write their own variant overrides" do

--- a/spec/models/variant_override_spec.rb
+++ b/spec/models/variant_override_spec.rb
@@ -89,18 +89,18 @@ describe VariantOverride do
 
   describe "resetting stock levels" do
     it "resets the on hand level to the value in the default_stock field" do
-      vo = create(:variant_override, variant: variant, hub: hub, count_on_hand: 12, default_stock: 20, enable_reset: true)
+      vo = create(:variant_override, variant: variant, hub: hub, count_on_hand: 12, default_stock: 20, resettable: true)
       vo.reset_stock!
       vo.reload.count_on_hand.should == 20
     end
     it "silently logs an error if the variant override doesn't have a default stock level" do
-      vo = create(:variant_override, variant: variant, hub: hub, count_on_hand: 12, default_stock:nil, enable_reset: true)
+      vo = create(:variant_override, variant: variant, hub: hub, count_on_hand: 12, default_stock:nil, resettable: true)
       Bugsnag.should_receive(:notify)
       vo.reset_stock!
       vo.reload.count_on_hand.should == 12
     end
     it "doesn't reset the level if the behaviour is disabled" do
-      vo = create(:variant_override, variant: variant, hub: hub, count_on_hand: 12, default_stock: 10, enable_reset: false)
+      vo = create(:variant_override, variant: variant, hub: hub, count_on_hand: 12, default_stock: 10, resettable: false)
       vo.reset_stock!
       vo.reload.count_on_hand.should == 12
     end


### PR DESCRIPTION
Hi Steve,

Nice work here, see my comments on your pull request, I'd like to hear your thoughts.

I had a bit of a crack at fixing up the VO specs, was a bit tricky because the major issue was occurring behind the scenes in CanCan and Spree, but basically it boils down to:
- CanCan (`ability_decorator.rb`) was not set up to allow anyone except admin to access the `:bulk_reset` action on the VO controller, so I fixed that.
- The reason `:bulk_update` was working was fairly unintuitive, there was a line in the ability decorator that was authorising :bulk_update actions on a nil object, which I think must have been a quick fix by someone who perhaps didn't understand how to authorise collection actions. I have removed it and made sure that any controllers which relied on it being there are now using the correct authorisation technique: see next point.
- The really tricky part is authorising collection actions on controllers that inherit from Spree's ResourceController. If you have a look at it Spree's code, you will see that every action has a before filter that calls a method: `load_resource`. This method tries to load an instance of the relevant model and authorise the action with on it. Obviously this wouldn't work for collection actions, so there is a clause that allows certain methods to be exempt from instance level authorisation based on whether the action name is included in the array returned by the `collection_actions` method on the relevant controller.
- I have added this `collection_actions` method to the VO controller and now everything seems to be hunky dory.
- I also refactored your specs a bit and added some extra contexts to test that authorisation was working broadly as we expect.

Thanks, speak soon.

Rob
