### PR TITLE
1067 so oc duplication

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/controllers/advanced.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/advanced.js.coffee
@@ -1,10 +1,10 @@
-angular.module('admin.orderCycles').controller 'AdminAdvancedOrderCyclesCtrl', ($rootScope, $scope, $filter, $location, $window, $q, $timeout, $http, OrderCycles, Enterprise, EnterpriseFee, StatusMessage, RequestMonitor) ->
+angular.module('admin.orderCycles').controller 'AdminAdvancedOrderCyclesCtrl', ($rootScope, $scope, $location, $timeout, $http, OrderCycles, StatusMessage) ->
   current_order_cycle_id = $location.absUrl().match(/\/admin\/order_cycles\/(\d+)/)[1]
-  $scope.order_cycles = OrderCycles.index(includeBlank: true, ams_prefix: "basic")
+  $scope.order_cycles = OrderCycles.index(ams_prefix: "basic")
   $scope.StatusMessage = StatusMessage
 
   $scope.copyProducts = ->
-    StatusMessage.display 'progress', t('admin.order_cycles.edit.copying_products')
+    StatusMessage.display 'progress', t('admin.order_cycles.edit.copying_products_and_fees')
     if angular.isDefined($scope.order_cycle_to_copy)
       $http
         method: "POST"
@@ -12,8 +12,8 @@ angular.module('admin.orderCycles').controller 'AdminAdvancedOrderCyclesCtrl', (
         data: { oc_to_copy: $scope.order_cycle_to_copy.id }
       .success (response) ->
         $rootScope.$emit('refreshOC', response.id)
-        $timeout -> t('admin.order_cycles.edit.products_copied')
+        StatusMessage.display 'progress', t('admin.order_cycles.edit.products_and_fees_copied_refreshing')
       .error (data, status) ->
-        $timeout -> StatusMessage.display 'failure', t('admin.order_cycles.edit.failed_to_copy_products') + ': ' + status
+        StatusMessage.display 'failure', t('admin.order_cycles.edit.failed_to_copy_products_and_fees') + ': ' + status
     else
       StatusMessage.display 'alert', t('admin.order_cycles.edit.select_an_order_cycle_first')

--- a/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
@@ -1,5 +1,5 @@
 angular.module('admin.orderCycles')
-  .controller 'AdminEditOrderCycleCtrl', ($rootScope, $scope, $filter, $location, $window, OrderCycle, Enterprise, EnterpriseFee, StatusMessage) ->
+  .controller 'AdminEditOrderCycleCtrl', ($rootScope, $scope, $filter, $location, $window, $q, OrderCycle, Enterprise, EnterpriseFee, StatusMessage) ->
     order_cycle_id = $location.absUrl().match(/\/admin\/order_cycles\/(\d+)/)[1]
     $scope.enterprises = Enterprise.index(order_cycle_id: order_cycle_id)
     $scope.supplier_enterprises = Enterprise.producer_enterprises
@@ -93,10 +93,8 @@ angular.module('admin.orderCycles')
       $window.location = destination
 
     $rootScope.$on 'refreshOC', (event, id) ->
-      StatusMessage.display 'success', t "admin.order_cycles.edit.order_cycle_updated"
       $scope.enterprises = Enterprise.index(order_cycle_id: id)
-      $scope.supplier_enterprises = Enterprise.producer_enterprises
-      $scope.distributor_enterprises = Enterprise.hub_enterprises
-      $scope.supplied_products = Enterprise.supplied_products
       $scope.enterprise_fees = EnterpriseFee.index(order_cycle_id: id)
       $scope.order_cycle = OrderCycle.load(id)
+      $q.all([$scope.enterprises.$promise, $scope.enterprise_fees.$promise, $scope.order_cycle.$promise]).then ->
+        StatusMessage.display 'success', t "admin.order_cycles.edit.order_cycle_updated"

--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -161,7 +161,7 @@ class AbilityDecorator
     can [:admin, :index, :read, :edit, :update], OrderCycle do |order_cycle|
       OrderCycle.accessible_by(user).include? order_cycle
     end
-    can [:bulk_update, :clone, :destroy, :notify_producers], OrderCycle do |order_cycle|
+    can [:bulk_update, :clone, :copy_settings, :destroy, :notify_producers], OrderCycle do |order_cycle|
       user.enterprises.include? order_cycle.coordinator
     end
     can [:for_order_cycle], Enterprise

--- a/app/views/admin/order_cycles/_advanced_settings.html.haml
+++ b/app/views/admin/order_cycles/_advanced_settings.html.haml
@@ -4,12 +4,12 @@
       %h3 Advanced Settings
 
   .row
-    .filter_select
-      %label.four.columns.alpha= t('admin.order_cycles.edit.copy_products_from')
-      %select.select2.four.columns#oc_id{ 'ng-model' => 'order_cycle_to_copy.id', name: 'order_cycle_to_copy_id', ng: { options: 'order_cycle.id as order_cycle.name for (id, order_cycle) in order_cycles' } }
-      .four.columns
-      .four.columns.alpha.omega.text-center
-        %input#copy_products{ type: 'button', value: 'Copy products', ng: { click: "copyProducts()" } }
+    .four-columns.alpha
+      %label.four.columns.alpha= t('admin.order_cycles.edit.copy_products_and_fees_from')
+    .four.columns.filter-select
+      %input.ofn-select2.fullwidth#oc_id{ ng: { model: 'order_cycle_to_copy.id' }, name: 'order_cycle_to_copy_id', data: 'order_cycles' }
+    .four.columns
+      %input#copy_products{ type: 'button', value: "#{t('admin.order_cycles.edit.copy_now')}", ng: { click: "copyProducts()" } }
 
   = form_for [main_app, :admin, @order_cycle] do |f|
     .row
@@ -24,7 +24,8 @@
       .four.columns.omega
         = f.radio_button :preferred_product_selection_from_coordinator_inventory_only, false
         = f.label :preferred_product_selection_from_coordinator_inventory_only, t("admin.order_cycles.edit.all_available_products")
-      .four.columns.alpha.omega.text-center
+    .row
+      .sixteen.columns.alpha.omega.text-center
         %input{ type: 'submit', value: t('admin.order_cycles.edit.save_and_reload_page') }
         %br
         = t('or')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -176,8 +176,11 @@ en:
       edit:
         choose_products_from: "Choose Products From:"
         copy_prefix: "COPY OF"
-        copying_products: "Copying products..."
-        failed_to_copy_products: "Failed to copy products"
+        copy_products_and_fees_from: "Copy products and fees from"
+        copy_now: "Copy Now"
+        copying_products_and_fees: "Copying products and fees..."
+        failed_to_copy_products_and_fees: "Failed to copy products"
+        products_and_fees_copied_refreshing: "Products and fees copied. Refreshing..."
         select_an_order_cycle_first: "Select an order cycle first."
         order_cycle_updated: "Order cycle updated."
         coordinators_inventory_only: "Co-ordinator's Inventory Only"


### PR DESCRIPTION
Hey mate,

Thanks for your work on this - love the use of AngularJS to live-update products and fees in the page! Very smooth!

I've just made a little change to help you on your way: added the #copy_settings action to the ability decorator (this is how we authorise access to admin actions - see [CanCan](https://github.com/ryanb/cancan) for more info). You should be right to keep going with your feature spec now.

The second commit just adds a couple of missing translations and tweaks the UI a bit, hope that is ok.

Only issue that I can see from my brief play around is that copying seems to duplicate products in outgoing exchanges in the UI. Any ideas what might be causing that?
